### PR TITLE
Fix the issue of identical get_data_list method in KITTI_2015 and KITTI_2012 and a small error in train.py

### DIFF
--- a/core/dataset/kitti_2012.py
+++ b/core/dataset/kitti_2012.py
@@ -22,9 +22,9 @@ class KITTI_2012(KITTI_Prepared):
         data_list = []
         for i in range(self.num_total):
             data = {}
-            data['img1_dir'] = os.path.join(self.data_dir, 'image_2', str(i).zfill(6) + '_10.png')
-            data['img2_dir'] = os.path.join(self.data_dir, 'image_2', str(i).zfill(6) + '_11.png')
-            data['calib_file_dir'] = os.path.join(self.data_dir, 'calib_cam_to_cam', str(i).zfill(6) + '.txt')
+            data['img1_dir'] = os.path.join(self.data_dir, 'colored_0', str(i).zfill(6) + '_10.png')
+            data['img2_dir'] = os.path.join(self.data_dir, 'colored_0', str(i).zfill(6) + '_11.png')
+            data['calib_file_dir'] = os.path.join(self.data_dir, 'calib', str(i).zfill(6) + '.txt')
             data_list.append(data)
         return data_list
 

--- a/core/dataset/kitti_2015.py
+++ b/core/dataset/kitti_2015.py
@@ -9,6 +9,16 @@ class KITTI_2015(KITTI_2012):
 
         self.data_list = self.get_data_list()
 
+    def get_data_list(self):
+        data_list = []
+        for i in range(self.num_total):
+            data = {}
+            data['img1_dir'] = os.path.join(self.data_dir, 'image_2', str(i).zfill(6) + '_10.png')
+            data['img2_dir'] = os.path.join(self.data_dir, 'image_2', str(i).zfill(6) + '_11.png')
+            data['calib_file_dir'] = os.path.join(self.data_dir, 'calib_cam_to_cam', str(i).zfill(6) + '.txt')
+            data_list.append(data)
+        return data_list        
+
 if __name__ == '__main__':
     pass
 

--- a/train.py
+++ b/train.py
@@ -164,7 +164,7 @@ if __name__ == '__main__':
         description="TrianFlow training pipeline."
     )
     arg_parser.add_argument('-c', '--config_file', default=None, help='config file.')
-    arg_parser.add_argument('-g', '--gpu', type=str, default=0, help='gpu id.')
+    arg_parser.add_argument('-g', '--gpu', type=str, default='0', help='gpu id.')
     arg_parser.add_argument('--batch_size', type=int, default=8, help='batch size.')
     arg_parser.add_argument('--iter_start', type=int, default=0, help='starting iteration.')
     arg_parser.add_argument('--lr', type=float, default=0.0001, help='learning rate')


### PR DESCRIPTION
- Since the data structure between KITTI_2015 and KITTI_2012 is different (e.g., image_2 -> colored_0), the get_data_list method in KITTI_2015 and KITTI_2012 should be different accordingly.
- The arg of gpu should be str type, otherwise the code of `num_gpus = len(args.gpu.split(','))` will produce error while running train.py